### PR TITLE
adding package import after blueprint definition

### DIFF
--- a/api/v1/views/__init__.py
+++ b/api/v1/views/__init__.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 """ init file which defines blueprint """
-from api.v1.views.index import *
 from flask import Blueprint
 
 app_views = Blueprint('app_views', __name__, url_prefix='/api/v1')
+
+from api.v1.views.index import *


### PR DESCRIPTION
In this commit I placed the import of the packages after the blueprint definition. Yet to understand the peculiarity of doing this this way